### PR TITLE
Add navigation to login and signup from home page

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:pws/screens/dashboard.dart';
+import 'package:pws/screens/home_page.dart';
+import 'package:pws/screens/signInScreen.dart';
 import 'package:pws/screens/signUpScreen.dart';
-import 'package:pws/screens/splash_screen.dart';
 
 void main() {
   runApp(const MyApp());
@@ -12,6 +12,18 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(debugShowCheckedModeBanner: false, home: SplashScreen());
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      home: HomeScreen(),
+      routes: {
+        '/home': (context) => HomeScreen(),
+        '/login': (context) => SignInScreen(),
+        '/signup': (context) => SignUpScreen(
+          navigate: (routename) {
+            Navigator.pushNamed(context, '/login');
+          },
+        ),
+      },
+    );
   }
 }

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -268,9 +268,9 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                           child: Column(
                             children: [
                               GestureDetector(
-                                onTap: () => animatePress(() {
-                                  // For now, do nothing. Add navigation logic later.
-                                }),
+                                onTap: () =>  {
+                                  Navigator.pushNamed(context, '/login')
+                                },
                                 child: Container(
                                   decoration: BoxDecoration(
                                     color: Colors.blue.shade800,
@@ -279,13 +279,6 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                                       color: Colors.white.withOpacity(0.5),
                                       width: 2,
                                     ),
-                                    boxShadow: [
-                                      BoxShadow(
-                                        color: Colors.black.withOpacity(0.1),
-                                        offset: const Offset(0, 4),
-                                        blurRadius: 8,
-                                      ),
-                                    ],
                                   ),
                                   padding: const EdgeInsets.symmetric(
                                     vertical: 20,
@@ -316,9 +309,9 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                                 ),
                               ),
                               GestureDetector(
-                                onTap: () => animatePress(() {
-                                  // For now, do nothing. Add navigation logic later.
-                                }),
+                                onTap: () =>  {
+                                  Navigator.pushNamed(context, '/signup')
+                                },
                                 child: Container(
                                   decoration: BoxDecoration(
                                     color: Colors.blue.shade800,
@@ -327,13 +320,6 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                                       color: Colors.white.withOpacity(0.5),
                                       width: 2,
                                     ),
-                                    boxShadow: [
-                                      BoxShadow(
-                                        color: Colors.black.withOpacity(0.1),
-                                        offset: const Offset(0, 4),
-                                        blurRadius: 8,
-                                      ),
-                                    ],
                                   ),
                                   padding: const EdgeInsets.symmetric(
                                     vertical: 20,


### PR DESCRIPTION
Replaced placeholder onTap handlers in HomeScreen with navigation to '/login' and '/signup' routes. Updated main.dart to set up named routes and set HomeScreen as the initial screen.