### PR TITLE
Add MainPage for auth-based routing and update navigation

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,14 +1,13 @@
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:pws/screens/dashboard.dart';
-
 import 'package:pws/screens/home_page.dart';
-import 'package:pws/screens/signInScreen.dart';
-import 'package:pws/screens/crop_calendar_screen.dart';
-import 'package:pws/screens/dashboard.dart';
+import 'package:pws/screens/main_page.dart';
 import 'package:pws/screens/reminder_screen.dart';
 import 'package:pws/screens/settings_screen.dart';
+import 'package:pws/screens/signInScreen.dart';
 import 'package:pws/screens/signUpScreen.dart';
+import 'package:pws/screens/weather_screen.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -23,7 +22,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
-      home: HomeScreen(),
+      home: MainPage(),
       routes: {
         '/home': (context) => HomeScreen(),
         '/login': (context) => SignInScreen(),
@@ -33,6 +32,9 @@ class MyApp extends StatelessWidget {
           },
         ),
         '/dashboard' : (context) => Dashboard(),
+        '/settings' : (context) => SettingsScreen(),
+        '/reminder' : (context) => ReminderScreen(),
+        '/weather' : (context) => WeatherScreen(),
       },
     );
   }

--- a/lib/screens/dashboard.dart
+++ b/lib/screens/dashboard.dart
@@ -338,7 +338,7 @@ class _DashboardState extends State<Dashboard> with TickerProviderStateMixin {
                                       horizontal: 8,
                                     ),
                                     child: SizedBox(
-                                      height: 140,
+                                      height: 171,
                                       child: ListView.builder(
                                         controller: _marketScrollController,
                                         scrollDirection: Axis.horizontal,

--- a/lib/screens/main_page.dart
+++ b/lib/screens/main_page.dart
@@ -1,0 +1,24 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:pws/screens/dashboard.dart';
+import 'package:pws/screens/home_page.dart';
+
+class MainPage extends StatelessWidget {
+  const MainPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: StreamBuilder<User?>(
+        stream: FirebaseAuth.instance.authStateChanges(),
+        builder: (context, snapshot) {
+          if (snapshot.hasData) {
+            return Dashboard();
+          } else {
+            return HomeScreen();
+          }
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/signInScreen.dart
+++ b/lib/screens/signInScreen.dart
@@ -30,18 +30,13 @@ class _SignInScreenState extends State<SignInScreen> {
       final userCredential = await FirebaseAuth.instance
           .signInWithEmailAndPassword(email: email, password: password);
       if (userCredential.user != null) {
-        Navigator.pushReplacementNamed(context, '/home');
+        Navigator.pushReplacementNamed(context, '/dashboard');
         return;
       }
 
       await Future.delayed(
         const Duration(seconds: 1),
-      ); // Simulate network delay
-      if (email == 'test@example.com' && password == 'password123') {
-        Navigator.pushReplacementNamed(context, '/home');
-      } else {
-        _showAlert('Invalid email or password.');
-      }
+      ); 
     } catch (e) {
       _showAlert('Sign in failed. Please try again.\nError: $e');
     } finally {

--- a/lib/screens/weather_screen.dart
+++ b/lib/screens/weather_screen.dart
@@ -11,7 +11,7 @@ class WeatherScreen extends StatefulWidget {
 
 class _WeatherScreenState extends State<WeatherScreen> {
   final String apiKey =
-      '23c58c68d34d415983a85602251106'; // Your WeatherAPI.com key
+      '23c58c68d34d415983a85602251106';
   final List<String> defaultCities = [
     'Gurgaon',
     'Mumbai',


### PR DESCRIPTION
Introduced MainPage to handle routing based on Firebase authentication state, directing users to Dashboard if authenticated or HomeScreen otherwise. Updated main.dart to use MainPage as the entry point and added new routes for settings, reminder, and weather screens. Adjusted sign-in navigation to redirect to Dashboard after login and increased the market list height in Dashboard.