### PR TITLE
Add community forum to navbar and enable chat navigation

### DIFF
--- a/lib/models/navBar.dart
+++ b/lib/models/navBar.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:pws/screens/communityForumScreen.dart';
 import 'package:pws/screens/crop_calendar_screen.dart';
 import 'package:pws/screens/dashboard.dart';
 import 'package:pws/screens/reminder_screen.dart';
@@ -16,6 +17,7 @@ class _NavbarState extends State<Navbar> {
   int selectedIndex = 2;
 
   final List<Widget> pages = [
+    CommunityForumScreen(),
     CropCalendarScreen(),
     WeatherScreen(),
     Dashboard(),
@@ -38,6 +40,10 @@ class _NavbarState extends State<Navbar> {
             });
           },
           items: const [
+            BottomNavigationBarItem(
+              icon: Icon(Icons.group),
+              label: 'Community',
+            ),
             BottomNavigationBarItem(
               icon: Icon(Icons.calendar_today),
               label: 'Calendar',

--- a/lib/screens/communityChatScreen.dart
+++ b/lib/screens/communityChatScreen.dart
@@ -1,8 +1,42 @@
 import 'package:flutter/material.dart';
-import 'package:pws/models/forum_post.dart';
-import 'package:pws/models/chat_message.dart'; // Make sure you have this model
-import 'package:flutter/services.dart';
-import 'dart:async';
+
+// ChatMessage model
+class ChatMessage {
+  final String id;
+  final String sender;
+  final String? text;
+  final String? voiceUrl;
+  final String timestamp;
+
+  ChatMessage({
+    required this.id,
+    required this.sender,
+    this.text,
+    this.voiceUrl,
+    required this.timestamp,
+  });
+}
+
+// ForumPost model (same as in forum screen)
+class ForumPost {
+  final String id;
+  final String user;
+  final String timestamp;
+  final String topic;
+  final String lastMessage;
+  final int messagesCount;
+  final bool voiceSupport;
+
+  ForumPost({
+    required this.id,
+    required this.user,
+    required this.timestamp,
+    required this.topic,
+    required this.lastMessage,
+    required this.messagesCount,
+    this.voiceSupport = false,
+  });
+}
 
 // Mock chat messages
 final List<ChatMessage> mockChatMessages = [
@@ -80,7 +114,7 @@ class _CommunityChatScreenState extends State<CommunityChatScreen> with SingleTi
         _chatMessages.add(newMessage);
         _messageController.clear();
       });
-      Timer(const Duration(milliseconds: 150), _scrollToBottom);
+      Future.delayed(const Duration(milliseconds: 150), _scrollToBottom);
     }
   }
 
@@ -103,7 +137,7 @@ class _CommunityChatScreenState extends State<CommunityChatScreen> with SingleTi
     setState(() {
       _chatMessages.add(newVoiceMessage);
     });
-    Timer(const Duration(milliseconds: 150), _scrollToBottom);
+    Future.delayed(const Duration(milliseconds: 150), _scrollToBottom);
     _showDialog('Voice Message', 'Voice message sent! (Mock)');
   }
 
@@ -215,10 +249,6 @@ class _CommunityChatScreenState extends State<CommunityChatScreen> with SingleTi
 
   @override
   Widget build(BuildContext context) {
-    SystemChrome.setSystemUIOverlayStyle(
-      SystemUiOverlayStyle.light.copyWith(statusBarColor: Colors.transparent),
-    );
-
     return Scaffold(
       backgroundColor: Colors.transparent,
       body: SafeArea(

--- a/lib/screens/communityForumScreen.dart
+++ b/lib/screens/communityForumScreen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:pws/models/forum_post.dart';
+import 'package:pws/screens/communityChatScreen.dart';
 
 class CommunityForumScreen extends StatelessWidget {
   CommunityForumScreen({Key? key}) : super(key: key);
@@ -26,8 +26,7 @@ class CommunityForumScreen extends StatelessWidget {
       user: 'Grower Geeta',
       timestamp: '3 days ago',
       topic: 'Sharing tips for rainwater harvesting',
-      lastMessage:
-          'My new pond system saved me a lot this season. Anyone else?',
+      lastMessage: 'My new pond system saved me a lot this season. Anyone else?',
       messagesCount: 56,
       voiceSupport: true,
     ),
@@ -130,101 +129,111 @@ class CommunityForumScreen extends StatelessWidget {
                     itemCount: mockForumPosts.length,
                     itemBuilder: (context, idx) {
                       final item = mockForumPosts[idx];
-                      return Container(
-                        margin: const EdgeInsets.only(bottom: 15),
-                        decoration: BoxDecoration(
-                          color: Colors.white.withOpacity(0.95),
-                          borderRadius: BorderRadius.circular(15),
-                          border: Border(
-                            left: BorderSide(color: Colors.blue, width: 5),
-                          ),
-                          boxShadow: [
-                            BoxShadow(
-                              color: Colors.black.withOpacity(0.15),
-                              offset: const Offset(0, 3),
-                              blurRadius: 8,
+                      return GestureDetector(
+                        onTap: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => CommunityChatScreen(postData: item),
                             ),
-                          ],
-                        ),
-                        child: Padding(
-                          padding: const EdgeInsets.all(15),
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Row(
-                                mainAxisAlignment:
-                                    MainAxisAlignment.spaceBetween,
-                                children: [
-                                  Text(
-                                    item.user,
-                                    style: const TextStyle(
-                                      fontSize: 16,
-                                      fontWeight: FontWeight.w700,
-                                      color: Color(0xFF1A3C34),
-                                    ),
-                                  ),
-                                  Text(
-                                    item.timestamp,
-                                    style: const TextStyle(
-                                      fontSize: 12,
-                                      color: Color(0xFF777777),
-                                    ),
-                                  ),
-                                ],
-                              ),
-                              const SizedBox(height: 5),
-                              Text(
-                                item.topic,
-                                style: const TextStyle(
-                                  fontSize: 18,
-                                  fontWeight: FontWeight.bold,
-                                  color: Color(0xFF333333),
-                                ),
-                              ),
-                              const SizedBox(height: 8),
-                              Text(
-                                'Last: "${item.lastMessage}"',
-                                style: const TextStyle(
-                                  fontSize: 14,
-                                  color: Color(0xFF555555),
-                                  fontStyle: FontStyle.italic,
-                                ),
-                              ),
-                              const SizedBox(height: 10),
-                              Row(
-                                mainAxisAlignment:
-                                    MainAxisAlignment.spaceBetween,
-                                children: [
-                                  Text(
-                                    '${item.messagesCount} messages',
-                                    style: const TextStyle(
-                                      fontSize: 12,
-                                      color: Color(0xFF666666),
-                                      fontWeight: FontWeight.w500,
-                                    ),
-                                  ),
-                                  if (item.voiceSupport)
-                                    Container(
-                                      padding: const EdgeInsets.symmetric(
-                                        horizontal: 8,
-                                        vertical: 4,
-                                      ),
-                                      decoration: BoxDecoration(
-                                        color: const Color(0xFFFFEB3B),
-                                        borderRadius: BorderRadius.circular(10),
-                                      ),
-                                      child: const Text(
-                                        '🎙️ Live Chat',
-                                        style: TextStyle(
-                                          fontSize: 12,
-                                          fontWeight: FontWeight.bold,
-                                          color: Color(0xFF333333),
-                                        ),
-                                      ),
-                                    ),
-                                ],
+                          );
+                        },
+                        child: Container(
+                          margin: const EdgeInsets.only(bottom: 15),
+                          decoration: BoxDecoration(
+                            color: Colors.white.withOpacity(0.95),
+                            borderRadius: BorderRadius.circular(15),
+                            border: Border(
+                              left: BorderSide(color: Colors.blue, width: 5),
+                            ),
+                            boxShadow: [
+                              BoxShadow(
+                                color: Colors.black.withOpacity(0.15),
+                                offset: const Offset(0, 3),
+                                blurRadius: 8,
                               ),
                             ],
+                          ),
+                          child: Padding(
+                            padding: const EdgeInsets.all(15),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Row(
+                                  mainAxisAlignment:
+                                      MainAxisAlignment.spaceBetween,
+                                  children: [
+                                    Text(
+                                      item.user,
+                                      style: const TextStyle(
+                                        fontSize: 16,
+                                        fontWeight: FontWeight.w700,
+                                        color: Color(0xFF1A3C34),
+                                      ),
+                                    ),
+                                    Text(
+                                      item.timestamp,
+                                      style: const TextStyle(
+                                        fontSize: 12,
+                                        color: Color(0xFF777777),
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                                const SizedBox(height: 5),
+                                Text(
+                                  item.topic,
+                                  style: const TextStyle(
+                                    fontSize: 18,
+                                    fontWeight: FontWeight.bold,
+                                    color: Color(0xFF333333),
+                                  ),
+                                ),
+                                const SizedBox(height: 8),
+                                Text(
+                                  'Last: "${item.lastMessage}"',
+                                  style: const TextStyle(
+                                    fontSize: 14,
+                                    color: Color(0xFF555555),
+                                    fontStyle: FontStyle.italic,
+                                  ),
+                                ),
+                                const SizedBox(height: 10),
+                                Row(
+                                  mainAxisAlignment:
+                                      MainAxisAlignment.spaceBetween,
+                                  children: [
+                                    Text(
+                                      '${item.messagesCount} messages',
+                                      style: const TextStyle(
+                                        fontSize: 12,
+                                        color: Color(0xFF666666),
+                                        fontWeight: FontWeight.w500,
+                                      ),
+                                    ),
+                                    if (item.voiceSupport)
+                                      Container(
+                                        padding: const EdgeInsets.symmetric(
+                                          horizontal: 8,
+                                          vertical: 4,
+                                        ),
+                                        decoration: BoxDecoration(
+                                          color: const Color(0xFFFFEB3B),
+                                          borderRadius: BorderRadius.circular(10),
+                                        ),
+                                        child: const Text(
+                                          '🎙️ Live Chat',
+                                          style: TextStyle(
+                                            fontSize: 12,
+                                            fontWeight: FontWeight.bold,
+                                            color: Color(0xFF333333),
+                                          ),
+                                        ),
+                                      ),
+                                  ],
+                                ),
+                              ],
+                            ),
                           ),
                         ),
                       );


### PR DESCRIPTION
Introduces the CommunityForumScreen to the navigation bar and allows users to tap forum posts to navigate to the CommunityChatScreen. Also moves ForumPost and ChatMessage models into the chat screen for local use and updates scrolling logic in chat. This improves the integration between forum and chat features.